### PR TITLE
Fixes for startup issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+charset = utf-8

--- a/library.js
+++ b/library.js
@@ -90,15 +90,22 @@ exports.init = function(params, callback) {
 
     if (settings.get('useCamoProxy')) {
       winston.info(C + "Starting Camo worker...");
-      var options = {silent: true, env: {
-        'CAMO_KEY': settings.get('key'),
-        'PORT': settings.get('port') || '8082'
-      }};
+
+      // Copy process.env into envCopy
+      var penv = process.env;
+      var envCopy = {};
+      for (var varName in penv) {
+        envCopy[varName] = penv[varName];
+      }
+      envCopy['CAMO_KEY'] = settings.get('key');
+      envCopy['PORT'] = settings.get('port') || 8082
+
+      var options = {silent: true, env: envCopy};
 
       loader = require("child_process").fork(__dirname + '/server', [], options);
 
       loader.stdout.on('data', function (data) { winston.info(CP + data); });
-      loader.stderr.on('data', function (data) { if (true || !isReloading) winston.error(CP + data); });
+      loader.stderr.on('data', function (data) { if (!isReloading) winston.error(CP + data); });
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodebb-plugin-camo",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "homepage": "https://github.com/minora-oss/nodebb-plugin-camo",
   "description": "Route embedded images through a secure camo proxy",
   "main": "library.js",

--- a/public/templates/admin/plugins/camo.tpl
+++ b/public/templates/admin/plugins/camo.tpl
@@ -107,7 +107,6 @@ require(['settings', 'https://cdn.jsdelivr.net/clipboard.js/1.5.9/clipboard.min.
         if ($('[data-key="useCamoProxy"]').is(':checked')) {
             $('[data-key="key"]').attr('disabled', '');
             $('[data-key="key"]').data('val', $('[data-key="key"]').val());
-            $('[data-key="key"]').val('internal');
         }
     });
 
@@ -118,6 +117,7 @@ require(['settings', 'https://cdn.jsdelivr.net/clipboard.js/1.5.9/clipboard.min.
         settings.persist('camo', $('#camo'), function(){
             socket.emit('admin.settings.syncCamo');
         });
+        location.reload(); // ghetto... refreshes the page to see generated key
     });
 
     $('[data-key="useCamoProxy"]').change(function() {
@@ -125,7 +125,7 @@ require(['settings', 'https://cdn.jsdelivr.net/clipboard.js/1.5.9/clipboard.min.
             $('[data-key="key"]').attr('disabled', '');
             $('[data-key="key"]').data('val', $('[data-key="key"]').val());
             $('[data-key="key"]').val('internal');
-        }else{
+        } else {
             $('[data-key="key"]').removeAttr('disabled');
             $('[data-key="key"]').val($('[data-key="key"]').data('val'));
         }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,16 @@
+var options = {silent: true, env: {
+  'CAMO_KEY': process.env.CAMO_KEY || 'banana',
+  'PORT': process.env.PORT || '8082'
+}};
+
+var camo = require("child_process").spawn('node', [__dirname + '/node_modules/camo/server'], options);
+
+camo.stdout.on('data', process.stdout.write);
+camo.stderr.on('data', function(){});
+
+process.on('SIGHUP', killWorker);
+process.on('disconnect', killWorker);
+
+function killWorker() {
+  camo.kill('SIGHUP');
+}

--- a/server.js
+++ b/server.js
@@ -1,12 +1,8 @@
-var options = {silent: true, env: {
-  'CAMO_KEY': process.env.CAMO_KEY || 'banana',
-  'PORT': process.env.PORT || '8082'
-}};
 
-var camo = require("child_process").spawn('node', [__dirname + '/node_modules/camo/server'], options);
+var camo = require("child_process").spawn('node', [__dirname + '/node_modules/camo/server'], { silent: true, env: process.env });
 
 camo.stdout.on('data', process.stdout.write);
-camo.stderr.on('data', function(){});
+camo.stderr.on('data', process.stderr.write);
 
 process.on('SIGHUP', killWorker);
 process.on('disconnect', killWorker);


### PR DESCRIPTION
1.2.2 wouldn't even start up because of invalid references, but I figured out what the ENOENT issue was: The child wasn't getting the PATH var, so calling `spawn('node'...` wouldn't know where "node" was located. This change passes all env vars down to the child processes. 

Some other minor tweaks including showing the generated key after saving, and displaying it upon returning to the admin panel
